### PR TITLE
Add Flask API and connect React UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 # Excel Tools Project
 
-This repository now provides a basic folder structure to separate the Python backend and the React frontend.
+This repository separates the Python backend from the React frontend.
 
 ```
 backend/   # Python scripts and dependencies
 frontend/  # React application
 ```
 
-The existing `ExtractIOandCovert.py` script has been moved to `backend/`.
+A simple Flask API (`backend/api.py`) exposes the Excel processing functions so
+Electron/React can call them.
+
+To run the API:
+```bash
+cd backend
+pip install -r requirements.txt
+python api.py
+```
+
+Start the development environment:
+```bash
+npm run dev
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,4 +2,27 @@
 
 This directory contains the Python backend for processing Excel files.
 
-Run the script directly for command line usage or build a REST API later.
+## Command Line Usage
+
+You can still run `ExtractIOandCovert.py` directly for interactive command line processing.
+
+## REST API
+
+A small Flask API is provided in `api.py` so the React frontend can trigger the
+existing functions.
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Start the API server:
+   ```bash
+   python api.py
+   ```
+   The server listens on port 5000 by default.
+
+Endpoints:
+- `POST /extract` – JSON body `{ "file_path": "/path/to/file.xlsx" }`
+- `POST /convert` – JSON body `{ "file_path": "/path/to/file.xlsx", "output_dir": "optional" }`
+
+Each endpoint returns JSON indicating success and the output location.

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,35 @@
+from flask import Flask, request, jsonify
+from flask_cors import CORS
+from ExtractIOandCovert import extract_io_list, convert_excel_to_csv
+
+app = Flask(__name__)
+CORS(app)
+
+@app.route('/extract', methods=['POST'])
+def extract():
+    data = request.get_json(force=True)
+    file_path = data.get('file_path')
+    if not file_path:
+        return jsonify({'error': 'file_path is required'}), 400
+
+    output_file = extract_io_list(file_path)
+    if output_file:
+        return jsonify({'success': True, 'output_file': output_file})
+    return jsonify({'success': False}), 500
+
+@app.route('/convert', methods=['POST'])
+def convert():
+    data = request.get_json(force=True)
+    file_path = data.get('file_path')
+    output_dir = data.get('output_dir')
+    if not file_path:
+        return jsonify({'error': 'file_path is required'}), 400
+
+    result_dir, generated_files = convert_excel_to_csv(file_path, output_dir)
+    if result_dir:
+        return jsonify({'success': True, 'output_dir': result_dir, 'files': generated_files})
+    return jsonify({'success': False}), 500
+
+if __name__ == '__main__':
+    app.run(port=5000)
+

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,5 @@
 pandas
 numpy
 openpyxl
+flask
+flask_cors

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,27 @@ import './App.css'
 
 function App() {
   const [count, setCount] = useState(0)
+  const [filePath, setFilePath] = useState('')
+  const [message, setMessage] = useState('')
+
+  const callApi = async (endpoint) => {
+    setMessage('Running...')
+    try {
+      const res = await fetch(`http://localhost:5000/${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ file_path: filePath })
+      })
+      const data = await res.json()
+      if (data.success) {
+        setMessage(JSON.stringify(data))
+      } else {
+        setMessage('Error running command')
+      }
+    } catch (err) {
+      setMessage('Request failed')
+    }
+  }
 
   return (
     <>
@@ -18,12 +39,20 @@ function App() {
       </div>
       <h1>Vite + React</h1>
       <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
+        <button onClick={() => setCount((c) => c + 1)}>count is {count}</button>
+        <div style={{ marginTop: '1rem' }}>
+          <input
+            placeholder="Excel file path"
+            value={filePath}
+            onChange={(e) => setFilePath(e.target.value)}
+            style={{ width: '300px' }}
+          />
+          <div style={{ marginTop: '0.5rem' }}>
+            <button onClick={() => callApi('extract')}>Extract IO List</button>
+            <button onClick={() => callApi('convert')} style={{ marginLeft: '0.5rem' }}>Convert to CSV</button>
+          </div>
+        </div>
+        <p>{message}</p>
       </div>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more


### PR DESCRIPTION
## Summary
- add minimal Flask API in `backend/api.py`
- update backend README with API instructions
- document API in the project README
- update requirements with Flask dependencies
- connect React UI buttons to call the new API

## Testing
- `python -m py_compile backend/api.py backend/ExtractIOandCovert.py`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68486a1627108320a1c506b5231e50e5